### PR TITLE
Fix flicker with popup menu

### DIFF
--- a/autoload/relativity.vim
+++ b/autoload/relativity.vim
@@ -58,10 +58,10 @@ function s:relativity_on()
   augroup relativity
     autocmd!
     if g:relativity_focus_toggle
-      autocmd BufEnter *    call s:enable_relative_number()
-      autocmd BufLeave *    call s:disable_relative_number()
-      autocmd WinEnter *    call s:enable_relative_number()
-      autocmd WinLeave *    call s:disable_relative_number()
+      autocmd BufEnter *    if !pumvisible() | call s:enable_relative_number() | endif
+      autocmd BufLeave *    if !pumvisible() | call s:disable_relative_number() | endif
+      autocmd WinEnter *    if !pumvisible() | call s:enable_relative_number() | endif
+      autocmd WinLeave *    if !pumvisible() | call s:disable_relative_number() | endif
       autocmd FocusLost *   call s:disable_relative_number()
       autocmd FocusGained * call s:enable_relative_number()
     endif


### PR DESCRIPTION
When using the completion menu if a menu item has additional infos associated, a preview window is opened to show these.
When the preview window is shown the cursor is briefly switched to the preview window and back to its original position thus triggering a BufLeave and corresponding BufEnter command. This can cause a function call, that may trigger a redraw causing a flicker while moving between popup menu result. Only executing those function when the popup menu is not visible fixes the issue.
